### PR TITLE
Fix for error when including multiple customs lines

### DIFF
--- a/lib/stamps/mapping.rb
+++ b/lib/stamps/mapping.rb
@@ -253,14 +253,15 @@ module Stamps
       # Maps :customs CustomsLine map
       def customs_lines=(customs)
         # Important:  Must call to_hash to force re-ordering!
-        self[:CustomsLines] = customs.collect{ |val| CustomsLinesArray.new(val).to_hash }
+        self[:CustomsLines] = CustomsLinesArray.new({ :custom => customs[:custom] })
       end
     end
 
     class CustomsLinesArray < Hashie::Trash
       property :CustomsLine,     :from => :custom
-      def custom=(val)
-        self[:CustomsLine] = CustomsLine.new(val).to_hash
+      def custom=(vals)
+        return unless vals
+        self[:CustomsLine] = vals.map{ |value| CustomsLine.new(value).to_hash }
       end
     end
 


### PR DESCRIPTION
Adding multiple customs line would generate invalid xml. 

instead of 
<CustomsLines>
  <CustomsLine>..</CustomsLine>
  <CustomsLine>..</CustomsLine>
</CustomsLines>

it currently generates

<CustomsLines>
  <CustomsLine>..</CustomsLine>
</CustomsLines>
<CustomsLines>
  <CustomsLine>..</CustomsLine>
</CustomsLines>

The change is based on a similar pattern used for AddOns